### PR TITLE
Fix get_synonym for words with no synonyms but with suggestions

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,18 +74,23 @@ function fetch_synonym(word, callback) {
             var $ = cheerio.load(html);
             var synonyms = [];
 
-            /* Populate 'synonyms' with all synonyms of highest relevance */
-            $('.relevancy-list ul').find('li a').filter(function(idx, elem) {
-                return JSON.parse($(this).attr('data-category')).name === 'relevant-3';
-            }).each(function(idx, elem) {
+            var all_synonyms = $('.relevancy-list ul').find('li a');
+
+            function populate_synonyms_from_link(idx, elem) {
                 synonyms[idx] = $(this).find('.text').text();
-            });
+            }
+
+            /* Populate 'synonyms' with all synonyms of highest relevance */
+            all_synonyms.filter(function(idx, elem) {
+                var category = $(this).attr('data-category');
+                return category && JSON.parse(category).name === 'relevant-3';
+            }).each(populate_synonyms_from_link);
 
             /* If no highly relevant synonyms found, just get any synonyms */
             if (synonyms.length === 0) {
-                $('.relevancy-list ul').find('li .text').each(function(idx, elem) {
-                    synonyms[idx] = $(this).text();
-                });
+                all_synonyms.filter(function(idx, elem) {
+                    return $(this).attr('data-complexity') !== undefined;
+                }).each(populate_synonyms_from_link);
             }
 
             /* If no synonyms found at all, return empty string */


### PR DESCRIPTION
Had a problem where bad words would be fetched if a word had no synonym and the
site instead had "Did you mean..." suggestions. This should be fixed.

I also refactored parts to make it slightly more readable.
